### PR TITLE
Add documentation links and TFLint configuration updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,11 +10,6 @@
       "matchPackagePrefixes": ["hashicorp/"],
       "matchUpdateTypes": ["minor", "patch"],
       "enabled": false
-    },
-    {
-      "matchPackagePrefixes": ["terraform-linters/"],
-      "matchUpdateTypes": ["patch"],
-      "enabled": false
     }
   ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/pre-commit-config.json
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
 
 repos:
   - repo: local

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,5 +1,7 @@
 plugin "terraform" {
   enabled = true
+  version = "0.12.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-terraform"
   preset  = "all"
 }
 


### PR DESCRIPTION
Include documentation links in the pre-commit example, add an external version of Terraform rules for TFLint, and remove the limit on renovate checks for TFLint.