### PR TITLE
feat: enable renovate pre-commit manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,9 @@
   "assignees": ["methridge"],
   "prHourlyLimit": 10,
   "reviewers": ["methridge"],
+  "pre-commit": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchPackagePrefixes": ["hashicorp/"],


### PR DESCRIPTION
## Summary

- Explicitly enables the Renovate `pre-commit` manager so that `rev` versions in `.pre-commit-config.yaml` are tracked and updated automatically

## Test plan

- [ ] Verify Renovate opens PRs for `pre-commit/pre-commit-hooks` and `antonbabenko/pre-commit-terraform` rev updates