### PR TITLE
chore: sync pre-commit config to canonical taskfiles template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,16 @@
 # yaml-language-server: $schema=https://json.schemastore.org/pre-commit-config.json
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
+      - id: check-added-large-files
       - id: check-merge-conflict
+      - id: check-yaml
       - id: end-of-file-fixer
       - id: no-commit-to-branch
+      - id: trailing-whitespace
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.108.0
     hooks:


### PR DESCRIPTION
Aligns `.pre-commit-config.yaml` with the canonical `precommit/terraform.yaml` in methridge/taskfiles.

Adds the standardized base hooks (`check-added-large-files`, `check-yaml`, `trailing-whitespace`) to the existing set. `pre-commit-terraform` was already at the canonical `v1.108.0`; the terraform hook block is unchanged. Nothing removed.

Validated with `pre-commit validate-config`; all hooks pass on commit.