### PR TITLE
chore: sync taskfiles to v1.1.0

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -40,7 +40,7 @@ tasks:
     # It is stamped at release time (see the `release:*` task). Upgrade explicitly
     # with TASKFILES_REF on the CLI or, durably, `export TASKFILES_REF` in .envrc.
     vars:
-      TASKFILES_REF: '{{.TASKFILES_REF | default "v1.0.1"}}'
+      TASKFILES_REF: '{{.TASKFILES_REF | default "v1.1.0"}}'
       TASKFILES_FILES: '{{.TASKFILES_FILES | default "git.yml scripts/lib.sh scripts/merge.sh scripts/review.sh"}}'
       BASE: 'https://raw.githubusercontent.com/methridge/taskfiles/{{.TASKFILES_REF}}'
     cmds:


### PR DESCRIPTION
Bumps vendored taskfiles pin to v1.1.0 via `task sync TASKFILES_REF=v1.1.0`.