### PR TITLE
fix: use pessimistic version constraints in provider examples

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -9,8 +9,8 @@
 # terraform {
 #   required_providers {
 #     google = {
-#       source = "hashicorp/google"
-#       version = "6.28.0"
+#       source  = "hashicorp/google"
+#       version = "~> 6.28"
 #     }
 #   }
 # }
@@ -24,7 +24,7 @@
 #   required_providers {
 #     hcp = {
 #       source  = "hashicorp/hcp"
-#       version = "0.104.0"
+#       version = "~> 0.104"
 #     }
 #   }
 # }


### PR DESCRIPTION
The template's stated convention is pessimistic version pinning (`~> Maj.Min`), and `terraform.tf` follows it with `~> 1.0`. The commented `required_providers` examples in `providers.tf` used exact pins instead, which contradicts the convention for anyone who copies them.

- `hashicorp/google`: `6.28.0` -> `~> 6.28`
- `hashicorp/hcp`: `0.104.0` -> `~> 0.104`

Also aligns the `source`/`version` `=` in the google example to match the hcp one. `terraform fmt` does not reach inside comments, so this had to be done by hand.