### PR TITLE
chore: sync taskfiles to v1.6.4

### DIFF
--- a/.taskfiles/shared/git.yml
+++ b/.taskfiles/shared/git.yml
@@ -33,14 +33,23 @@ tasks:
       - pre-commit run -a
 
   push:
-    desc: "Commit all changes and push (branching off main if needed)"
+    desc: "Commit changes and push (branching off main if needed, staging only tracked changes by default)"
+    vars:
+      MESSAGE: '{{.MESSAGE | default (printf "chore: %s" .CURRENT_DATE)}}'
+      BRANCH: '{{.BRANCH | default ""}}'
+      FILES: '{{.FILES | default "."}}'
+      ALLOW_UNTRACKED: '{{.ALLOW_UNTRACKED | default "false"}}'
+    preconditions:
+      - sh: "echo '{{.MESSAGE}}' | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\([a-zA-Z0-9_.-]+\\))?!?: .+'"
+        msg: |
+          Commit message must be a Conventional Commit: <type>(<scope>)?!: <description>
+          Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+          Example: fix(auth): handle expiry
+          Got: '{{.MESSAGE}}'
     cmds:
       - |
-        if [[ $(git rev-parse --abbrev-ref HEAD) == "main" ]]; then
-          git switch --create {{.CURRENT_DATE}}
-        fi
-      - git add .
-      - git commit -m "{{.CURRENT_DATE}}"
+        MESSAGE="{{.MESSAGE}}" BRANCH="{{.BRANCH}}" CURRENT_DATE="{{.CURRENT_DATE}}" FILES="{{.FILES}}" ALLOW_UNTRACKED="{{.ALLOW_UNTRACKED}}" .taskfiles/shared/scripts/push.sh
+      - git commit -m "{{.MESSAGE}}"
       - git push
 
   review:*:

--- a/.taskfiles/shared/scripts/push.sh
+++ b/.taskfiles/shared/scripts/push.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Backs the `push` task in git.yml. Handles two things the Taskfile YAML
+# can't express cleanly:
+#
+#   1. Branch naming: when on main, derive a <type>/<slug> branch name from
+#      the (already Conventional-Commit-validated) MESSAGE, unless BRANCH
+#      overrides it.
+#   2. git-add safety: refuse to silently sweep up new untracked files;
+#      require an explicit opt-in (ALLOW_UNTRACKED=true) or explicit paths
+#      (FILES=...).
+#
+# Env vars (all set by the `push` task, all have safe defaults):
+#   MESSAGE           Conventional Commit message.
+#   BRANCH            Explicit branch name override; used verbatim if set.
+#   CURRENT_DATE      Fallback slug source (shared CURRENT_DATE var).
+#   FILES             Paths to stage. Default ".".
+#   ALLOW_UNTRACKED   "true" to allow untracked files when FILES is ".".
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+MESSAGE="${MESSAGE:-}"
+BRANCH="${BRANCH:-}"
+CURRENT_DATE="${CURRENT_DATE:-}"
+FILES="${FILES:-.}"
+ALLOW_UNTRACKED="${ALLOW_UNTRACKED:-false}"
+
+# Sanitize free text into a safe branch-name component: lowercase, collapse
+# runs of non-alphanumerics to a single hyphen, strip leading/trailing
+# hyphens, cap length, then strip any hyphen left dangling by truncation.
+sanitize_slug() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+    | cut -c1-40 \
+    | sed -E 's/-+$//'
+}
+
+# Derive "<type>/<slug>" from MESSAGE. MESSAGE is already validated upstream
+# by the task's Conventional Commit precondition; the fallback branch below
+# is defensive only and should be unreachable in normal use.
+branch_from_message() {
+  local re='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-zA-Z0-9_.-]+\))?!?: (.+)$'
+  local type desc slug
+  if [[ "${MESSAGE}" =~ ${re} ]]; then
+    type="${BASH_REMATCH[1]}"
+    desc="${BASH_REMATCH[3]}"
+  else
+    type="chore"
+    desc="${MESSAGE}"
+  fi
+
+  slug="$(sanitize_slug "${desc}")"
+  if [[ -z "${slug}" ]]; then
+    # Description sanitized away to nothing (e.g. "chore: ---"); fall back
+    # to the timestamp so we never produce an invalid "type/" ref.
+    slug="$(sanitize_slug "${CURRENT_DATE}")"
+  fi
+
+  printf '%s/%s\n' "${type}" "${slug}"
+}
+
+# Append -2, -3, ... until the name is free, locally and on origin. Avoids
+# both a confusing raw "branch already exists" error and silently reusing
+# an unrelated branch's history.
+unique_branch() {
+  local base="$1" candidate="$1" n=2
+  while git show-ref --verify --quiet "refs/heads/${candidate}" \
+     || git ls-remote --exit-code --heads origin "${candidate}" >/dev/null 2>&1; do
+    candidate="${base}-${n}"
+    n=$((n + 1))
+  done
+  printf '%s\n' "${candidate}"
+}
+
+if [[ "$(git rev-parse --abbrev-ref HEAD)" == "main" ]]; then
+  if [[ -n "${BRANCH}" ]]; then
+    target_branch="${BRANCH}"
+  else
+    target_branch="$(unique_branch "$(branch_from_message)")"
+  fi
+  git switch --create "${target_branch}"
+fi
+
+# Only guard the default "stage everything" case. Explicit FILES is already
+# a deliberate act, so it bypasses the safety net by design.
+if [[ "${FILES}" == "." && "${ALLOW_UNTRACKED}" != "true" ]]; then
+  untracked=()
+  while IFS= read -r -d '' entry; do
+    [[ "${entry:0:2}" == "??" ]] && untracked+=("${entry:3}")
+  done < <(git status --porcelain=v1 --untracked-files=all -z)
+
+  if ((${#untracked[@]} > 0)); then
+    echo "Refusing to stage: new untracked file(s) would be swept into this commit:" >&2
+    printf '  %s\n' "${untracked[@]}" >&2
+    echo >&2
+    echo "Options:" >&2
+    echo "  - task push ALLOW_UNTRACKED=true          # include them" >&2
+    echo '  - task push FILES="path/a path/b"          # stage specific paths instead' >&2
+    exit 1
+  fi
+fi
+
+# shellcheck disable=SC2086 # FILES may be a space-separated list of paths
+git add ${FILES}

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -47,8 +47,8 @@ tasks:
     # It is stamped at release time (see the `release:*` task). Upgrade explicitly
     # with TASKFILES_REF on the CLI or, durably, `export TASKFILES_REF` in .envrc.
     vars:
-      TASKFILES_REF: '{{.TASKFILES_REF | default "v1.6.0"}}'
-      TASKFILES_FILES: '{{.TASKFILES_FILES | default "git.yml scripts/lib.sh scripts/merge.sh scripts/review.sh"}}'
+      TASKFILES_REF: '{{.TASKFILES_REF | default "v1.6.4"}}'
+      TASKFILES_FILES: '{{.TASKFILES_FILES | default "git.yml scripts/lib.sh scripts/merge.sh scripts/push.sh scripts/review.sh"}}'
       # Claude Code plugin profile for this repo (claude/<name>.json upstream).
       # Resolution order, high to low: a CLI arg (TASKFILES_CLAUDE_PROFILE=...)
       # -> the value from .taskfiles/config, if present (loaded above via
@@ -131,7 +131,7 @@ tasks:
       PROFILE: "{{index .MATCH 0}}"
       # Same resolution as `sync` above - kept in lockstep by `task release`,
       # which stamps every `default "vX.Y.Z"` in this file together.
-      TASKFILES_REF: '{{.TASKFILES_REF | default "v1.6.0"}}'
+      TASKFILES_REF: '{{.TASKFILES_REF | default "v1.6.4"}}'
       TASKFILES_BASE: '{{.TASKFILES_BASE | default (print "https://raw.githubusercontent.com/methridge/taskfiles/" .TASKFILES_REF)}}'
     cmds:
       # Validate the name resolves upstream before writing anything - a


### PR DESCRIPTION
Re-vendors the shared taskfiles from methridge/taskfiles v1.6.4.

- `Taskfile.yaml` - regenerated; `TASKFILES_REF` default now `v1.6.4`
- `.taskfiles/shared/git.yml` - upstream rework
- `.taskfiles/shared/scripts/push.sh` - new shared script

Vendored files only; `.taskfiles/project/` is untouched. Generated by `task sync`.

https://claude.ai/code/session_0157NPsRWgLCthgJ8hpXHE28